### PR TITLE
fix: ajoute validation des intrants pour les certificateurs

### DIFF
--- a/frontend-dapp/src/App.jsx
+++ b/frontend-dapp/src/App.jsx
@@ -101,7 +101,7 @@ function AppLayout({ state, setState, account, setAccount, role, setRole, sideba
           roleLinks = [{ to: "/mes-parcelles", text: "Gérer les Intrants" }]; break;
         case 2:
           roleLinks = [
-            { to: "/mes-parcelles", text: "Contrôle Phytosanitaire Parcelle" },
+            { to: "/mes-parcelles", text: "Validation des intrants" },
             { to: "/liste-recolte", text: "Contrôle Phytosanitaire Recolte" }
           ]; break;
         case 3:

--- a/frontend-dapp/src/components/Tools/ParcelleCard.jsx
+++ b/frontend-dapp/src/components/Tools/ParcelleCard.jsx
@@ -45,8 +45,8 @@ const ParcelleCard = ({
     // Liens pour le certificateur
     if (userRole === 2) {
       links.push(
-        <Link key="inspections" to={`/parcelle/${id}/inspections`} className="btn btn-link">
-          Inspections
+        <Link key="intrants" to={`/parcelle/${id}/intrants`} className="btn btn-link">
+          Intrants
         </Link>
       );
     }


### PR DESCRIPTION
Ajoute l’option de validation des intrants des parcelles par le certificateur. 

Pourquoi ? avant c’etait l’option de faire des inspections sur les parcelles qui doit être normalement faite par des auditeurs. 

@tsii06
